### PR TITLE
Add initial site layout

### DIFF
--- a/assets/hero.jpg
+++ b/assets/hero.jpg
@@ -1,0 +1,1 @@
+placeholder image

--- a/assets/instructora.jpg
+++ b/assets/instructora.jpg
@@ -1,0 +1,1 @@
+placeholder image

--- a/index.html
+++ b/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="es-AR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Teclas Ciudad Jardín</title>
+  <link rel="stylesheet" href="style.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&family=Nunito:wght@400;700&display=swap" rel="stylesheet">
+</head>
+<body>
+  <header class="navbar">
+    <div class="container">
+      <h1 class="logo">Teclas Ciudad Jardín</h1>
+      <nav>
+        <ul>
+          <li><a href="#academia">La Academia</a></li>
+          <li><a href="#profesora">La Profesora</a></li>
+          <li><a href="#inscripcion">Inscripción</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <section class="hero" id="hero">
+    <div class="overlay">
+      <h2>Domina el arte del piano con clases personalizadas</h2>
+      <p>Comienza hoy mismo y reserva tu primera clase.</p>
+      <a href="https://forms.gle/your-google-form" target="_blank" class="btn-primary">Comienza hoy mismo</a>
+      <a href="#plan" class="link-secondary">Ver plan de estudios</a>
+    </div>
+  </section>
+
+  <section class="why" id="benefits">
+    <h2>¿Por qué elegir nuestra academia?</h2>
+    <div class="grid">
+      <div class="feature">
+        <div class="icon">🎯</div>
+        <h3>Enfoque personalizado</h3>
+        <p>Clases adaptadas a tu nivel.</p>
+      </div>
+      <div class="feature">
+        <div class="icon">🎹</div>
+        <h3>Instrucción experta</h3>
+        <p>Profesores con años de experiencia.</p>
+      </div>
+      <div class="feature">
+        <div class="icon">🤝</div>
+        <h3>Comunidad de apoyo</h3>
+        <p>Recitales regulares y eventos.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="instructor" id="profesora">
+    <div class="container">
+      <img src="assets/instructora.jpg" alt="Foto de la instructora" class="portrait">
+      <div class="bio">
+        <h2>Conocé tu instructora</h2>
+        <p>Roxana se formó en el Conservatorio Beethoven y la UNC. Cuenta con más de 14 años enseñando a niños desde los 4 años hasta adultos. Su método es interactivo, divertido y efectivo.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="philosophy" id="filosofia">
+    <div class="container">
+      <h2>Nuestra filosofía de enseñanza</h2>
+      <p>Brindamos atención personalizada y motivación positiva, utilizando recursos adaptados a cada etapa. Creemos que la música desarrolla habilidades para toda la vida.</p>
+    </div>
+  </section>
+
+  <section class="cta-final" id="inscripcion">
+    <h2>¿Listo para comenzar tu viaje en el piano?</h2>
+    <a href="https://forms.gle/your-google-form" target="_blank" class="btn-primary">Inscribirme ahora</a>
+    <a href="https://wa.me/5491134162288" class="btn-secondary">Escribir por WhatsApp</a>
+  </section>
+
+  <footer>
+    <div class="container">
+      <p><strong>Teclas Ciudad Jardín</strong> — Clases de piano personalizadas en Ciudad Jardín</p>
+      <p>Ciudad Jardín Lomas del Palomar, Buenos Aires | Tel: <a href="tel:+5491134162288">(+54) 9 11 3416-2288</a></p>
+      <p>Síguenos en <a href="https://www.instagram.com/teclas.ciudadjardin/" target="_blank">@teclas.ciudadjardin</a></p>
+      <p>&copy; 2025 Teclas Ciudad Jardín. Todos los derechos reservados.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,148 @@
+body {
+  font-family: 'Nunito', sans-serif;
+  margin: 0;
+  line-height: 1.6;
+}
+
+.navbar {
+  position: sticky;
+  top: 0;
+  background: #ffffff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+}
+.navbar .container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+}
+.navbar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 1rem;
+}
+.navbar a {
+  text-decoration: none;
+  color: #1F2937;
+  font-weight: 600;
+}
+
+.hero {
+  background: url('assets/hero.jpg') center/cover no-repeat;
+  min-height: 80vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: white;
+  position: relative;
+}
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+}
+.hero .overlay {
+  position: relative;
+  z-index: 1;
+}
+.hero h2 {
+  font-family: 'Montserrat', sans-serif;
+  font-size: 2rem;
+}
+.btn-primary {
+  display: inline-block;
+  background: #0077FF;
+  color: white;
+  padding: 0.75rem 1.25rem;
+  border-radius: 8px;
+  margin: 1rem 0.5rem;
+  text-decoration: none;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+.btn-secondary {
+  display: inline-block;
+  background: #0a65c0;
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  text-decoration: none;
+}
+.link-secondary {
+  display: block;
+  margin-top: 0.5rem;
+  color: #E0E0E0;
+}
+
+.why {
+  background: #F3F4F6;
+  padding: 4rem 1rem;
+  text-align: center;
+}
+.why .grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 2rem;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+.why .feature {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.icon {
+  font-size: 2rem;
+}
+
+.instructor .container {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 2rem;
+  padding: 4rem 1rem;
+}
+.portrait {
+  max-width: 300px;
+  border-radius: 8px;
+  width: 100%;
+}
+.bio {
+  flex: 1;
+}
+
+.philosophy {
+  background: #F8FAFC;
+  padding: 4rem 1rem;
+  text-align: center;
+}
+
+.cta-final {
+  background: #1F2937;
+  color: white;
+  padding: 3rem 1rem;
+  text-align: center;
+}
+
+footer {
+  background: #eee;
+  padding: 2rem 1rem;
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+@media (max-width: 600px) {
+  .navbar .container {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- add a single-page HTML layout with hero, benefits, bio, philosophy, and footer
- style the layout with a simple CSS file
- include placeholder assets

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6861893118488326ac3421ecf3ebe881